### PR TITLE
feat: disable duplicate name for public bot

### DIFF
--- a/crates/core/result/src/lib.rs
+++ b/crates/core/result/src/lib.rs
@@ -32,7 +32,7 @@ pub struct Error {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
 #[cfg_attr(feature = "schemas", derive(JsonSchema))]
-#[derive(Debug, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum ErrorType {
     /// This error was not labeled :(
     LabelMe,
@@ -94,6 +94,7 @@ pub enum ErrorType {
     ReachedMaximumBots,
     IsBot,
     BotIsPrivate,
+    DuplicatePublicBotName,
 
     // ? User safety related errors
     CannotReportYourself,

--- a/crates/core/result/src/rocket.rs
+++ b/crates/core/result/src/rocket.rs
@@ -53,6 +53,7 @@ impl<'r> Responder<'r, 'static> for Error {
             ErrorType::ReachedMaximumBots => Status::BadRequest,
             ErrorType::IsBot => Status::BadRequest,
             ErrorType::BotIsPrivate => Status::Forbidden,
+            ErrorType::DuplicatePublicBotName => Status::Forbidden,
 
             ErrorType::CannotReportYourself => Status::BadRequest,
 

--- a/crates/delta/src/routes/bots/create.rs
+++ b/crates/delta/src/routes/bots/create.rs
@@ -125,7 +125,7 @@ async fn create_default_channel_for_bot(
     let server = Server {
         id: server_id.clone(),
         owner: user.id.clone(),
-        name: bot_name + "的社区",
+        name: bot_name + "的主页",
         description: None,
         channels: vec![channel_id],
         nsfw: false,

--- a/crates/delta/src/routes/bots/create.rs
+++ b/crates/delta/src/routes/bots/create.rs
@@ -199,8 +199,11 @@ mod test {
 
         assert_eq!(response.status(), Status::Ok);
 
-        let bot: v0::Bot = response.into_json().await.expect("`Bot`");
-        assert!(harness.db.fetch_bot(&bot.id).await.is_ok());
+        let bot_response: v0::Bot = response.into_json().await.expect("`Bot`");
+        let bot = harness.db.fetch_bot(&bot_response.id).await.unwrap();
+
+        assert!(bot.server_invite.is_some());
+        assert!(bot.default_server.is_some());
     }
 
     #[test]

--- a/crates/delta/src/routes/bots/edit.rs
+++ b/crates/delta/src/routes/bots/edit.rs
@@ -42,6 +42,28 @@ pub async fn edit_bot(
         return Ok(Json(bot.into()));
     }
 
+    if let Some(true) = data.public {
+        let bots = db.fetch_discoverable_bots().await?;
+        let mut user_ids = bots
+            .into_iter()
+            .map(|x| x.id.clone())
+            .collect::<Vec<String>>();
+
+        user_ids.push(bot.id.clone());
+        let users = db.fetch_users(&user_ids).await?;
+        let bot_user = users
+            .iter()
+            .find(|x| *x.id == bot.id)
+            .ok_or_else(|| create_error!(NotFound))?;
+
+        if users
+            .iter()
+            .any(|x| *x.id != bot_user.id && *x.username == bot_user.username)
+        {
+            return Err(create_error!(DuplicatePublicBotName));
+        }
+    }
+
     let DataEditBot {
         public,
         analytics,
@@ -74,8 +96,9 @@ pub async fn edit_bot(
 #[cfg(test)]
 mod test {
     use crate::{rocket, util::test::TestHarness};
-    use revolt_database::Bot;
+    use revolt_database::{Bot, PartialBot};
     use revolt_models::v0::{self, FieldsBot};
+    use revolt_result::{Error, ErrorType};
     use rocket::http::{ContentType, Header, Status};
 
     #[rocket::async_test]
@@ -103,10 +126,54 @@ mod test {
             .dispatch()
             .await;
 
+        // info!("{}", response.into_string().await.unwrap());
         assert_eq!(response.status(), Status::Ok);
 
         let updated_bot: v0::Bot = response.into_json().await.expect("`Bot`");
         assert!(!bot.public);
         assert!(updated_bot.public);
+    }
+
+    #[rocket::async_test]
+    async fn add_duplicated_public_bot() {
+        let harness = TestHarness::new().await;
+        let (_, session, user) = harness.new_user().await;
+
+        let bot_name = TestHarness::rand_string();
+        let bot1 = Bot::create(&harness.db, bot_name.clone(), &user, None)
+            .await
+            .expect("`Bot`");
+
+        let _ = Bot::create(
+            &harness.db,
+            bot_name.clone(),
+            &user,
+            PartialBot {
+                public: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("`Bot`");
+
+        let response = harness
+            .client
+            .patch(format!("/bots/{}", bot1.id))
+            .header(ContentType::JSON)
+            .body(
+                json!(v0::DataEditBot {
+                    public: Some(true),
+                    ..Default::default()
+                })
+                .to_string(),
+            )
+            .header(Header::new("x-session-token", session.token.to_string()))
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::Forbidden);
+
+        let err = response.into_json::<Error>().await.unwrap();
+        assert_eq!(err.error_type, ErrorType::DuplicatePublicBotName);
     }
 }

--- a/crates/delta/src/routes/bots/fetch_discover.rs
+++ b/crates/delta/src/routes/bots/fetch_discover.rs
@@ -23,7 +23,6 @@ pub async fn fetch_discoverable_bots(db: &State<Database>) -> Result<Json<OwnedB
     bots.sort_by(|a, b| a.id.cmp(&b.id));
     users.sort_by(|a, b| a.id.cmp(&b.id));
 
-    // Ok(Json(OwnedBotsResponse { users, bots }))
     Ok(Json(OwnedBotsResponse {
         users: join_all(users.into_iter().map(|user| user.into_self())).await,
         bots: bots.into_iter().map(|bot| bot.into()).collect(),

--- a/crates/delta/src/util/ratelimiter.rs
+++ b/crates/delta/src/util/ratelimiter.rs
@@ -138,7 +138,7 @@ fn resolve_bucket<'r>(request: &'r rocket::Request<'_>) -> (&'r str, Option<&'r 
 /// Resolve per-bucket limits
 fn resolve_bucket_limit(bucket: &str) -> u8 {
     match bucket {
-        "user_edit" => 2,
+        "user_edit" => 10,
         "users" => 20,
         "bots" => 10,
         "messaging" => 10,


### PR DESCRIPTION
1. Disable duplicate name for public bot
2. Disable permission check for DM
3. Adjust rate limiting for user_edit
4. Update the bot's server name